### PR TITLE
Fix MCP mode console output interference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -342,13 +342,19 @@ async function startCLIMode() {
 // Main entry point
 async function main() {
   try {
+    // Determine run mode first
+    const runMode = determineRunMode();
+    
+    // MCPモードの場合は早期にログを無効化
+    if (runMode === 'mcp') {
+      logger.setMcpMode(true);
+    }
+    
     // Initialize project context
     const contextManager = ProjectContextManager.getInstance();
     await contextManager.initialize(process.cwd());
     
-    // Determine and execute run mode
-    const runMode = determineRunMode();
-    
+    // Execute run mode
     if (runMode === 'mcp') {
       await startMCPServer();
     } else {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 export class Logger {
   private static instance: Logger;
   private logLevel: 'debug' | 'info' | 'warn' | 'error' = 'info';
+  private mcpMode: boolean = false;
 
   static getInstance(): Logger {
     if (!Logger.instance) {
@@ -11,6 +12,10 @@ export class Logger {
 
   setLogLevel(level: 'debug' | 'info' | 'warn' | 'error'): void {
     this.logLevel = level;
+  }
+
+  setMcpMode(enabled: boolean): void {
+    this.mcpMode = enabled;
   }
 
   private shouldLog(level: string): boolean {
@@ -27,25 +32,25 @@ export class Logger {
   }
 
   debug(message: string, meta?: any): void {
-    if (this.shouldLog('debug')) {
+    if (this.shouldLog('debug') && !this.mcpMode) {
       console.debug(this.formatMessage('debug', message, meta));
     }
   }
 
   info(message: string, meta?: any): void {
-    if (this.shouldLog('info')) {
+    if (this.shouldLog('info') && !this.mcpMode) {
       console.info(this.formatMessage('info', message, meta));
     }
   }
 
   warn(message: string, meta?: any): void {
-    if (this.shouldLog('warn')) {
+    if (this.shouldLog('warn') && !this.mcpMode) {
       console.warn(this.formatMessage('warn', message, meta));
     }
   }
 
   error(message: string, meta?: any): void {
-    if (this.shouldLog('error')) {
+    if (this.shouldLog('error') && !this.mcpMode) {
       console.error(this.formatMessage('error', message, meta));
     }
   }


### PR DESCRIPTION
## Summary

- MCPモード時にLoggerクラスのコンソール出力がJSON-RPC通信を妨害していた問題を修正
- Logger クラスに mcpMode フラグを追加し、MCPモード時はコンソール出力を無効化
- モード判定を早期に実行してログを制御

## Test plan

- [x] TypeScriptビルドが成功することを確認
- [x] MCPモードでのJSON-RPC通信が正常に動作することを確認
- [x] CLIモードでのログ出力が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)